### PR TITLE
日記を見るページを作成

### DIFF
--- a/lib/component/searchWidget.dart
+++ b/lib/component/searchWidget.dart
@@ -3,12 +3,20 @@ import 'package:flutter/material.dart';
 class SearchWidget extends StatelessWidget {
   const SearchWidget({
     super.key,
+    required this.hint,
   });
+
+  final String hint;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
-      decoration: InputDecoration(prefixIcon: Icon(Icons.search)),
+      decoration: InputDecoration(
+        hintText: hint,
+        prefixIcon: const Icon(
+          Icons.search,
+        ),
+      ),
       onChanged: (text) {},
     );
   }

--- a/lib/diaryList.dart
+++ b/lib/diaryList.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class DiaryList extends StatelessWidget {
+  const DiaryList({Key? key, required this.mode}) : super(key: key);
+
+  final Mode mode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text("");
+  }
+}
+
+enum Mode {
+  myself,
+  follow,
+  timeline,
+}

--- a/lib/diaryList.dart
+++ b/lib/diaryList.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:omurice/diaryListItem.dart';
 
 class DiaryList extends StatelessWidget {
   const DiaryList({Key? key, required this.mode}) : super(key: key);
@@ -7,7 +8,24 @@ class DiaryList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text("");
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
+      itemBuilder: (context, index) {
+        return DiaryListItem(
+          userName: dummyDiaryDataList[index].userName,
+          avatarUrl: dummyDiaryDataList[index].avatarUrl,
+          diaryText: dummyDiaryDataList[index].diaryText,
+          isBookmarked: dummyDiaryDataList[index].isBookmarked,
+          onTapBookmark: () {},
+        );
+      },
+      separatorBuilder: (context, index) {
+        return const Divider(
+          thickness: 2,
+        );
+      },
+      itemCount: dummyDiaryDataList.length,
+    );
   }
 }
 
@@ -15,4 +33,50 @@ enum Mode {
   myself,
   follow,
   timeline,
+}
+
+List<DiaryData> dummyDiaryDataList = makeDummyList();
+const dummyDiaryDataListBase = [
+  DiaryData(
+    userName: "みどり",
+    avatarUrl: null,
+    diaryText: "視覚：おいしそうなごはん\n聴覚：楽しい音楽\n触覚：さむい\n味覚：唐揚げおいしい\n嗅覚：？？？？？？？",
+    isBookmarked: false,
+  ),
+  DiaryData(
+    userName: "青子",
+    avatarUrl: dummyAvatarUrl,
+    diaryText: "過去の自分へ\n\n友達ができないと悩んでいた私へ\n名前が覚えられないほど仲間ができたよ",
+    isBookmarked: false,
+  ),
+  DiaryData(
+    userName: "赤太郎",
+    avatarUrl: null,
+    diaryText: "困っていること\n\nストレス、疲れに気づかない\n完ぺき主義",
+    isBookmarked: true,
+  ),
+];
+
+List<DiaryData> makeDummyList() {
+  List<DiaryData> list = [];
+  for (var i = 0; i < 100; i++) {
+    list.addAll(dummyDiaryDataListBase);
+  }
+  return list;
+}
+
+const dummyAvatarUrl =
+    "https://1.bp.blogspot.com/-pzkUACogq0E/X5OcHr5ZnSI/AAAAAAABb5Q/xb-j2PQXgu03_vypUL1XNOYv4bhpWEFgQCNcBGAsYHQ/s180-c/bird_mameruriha_inko_blue.png";
+
+class DiaryData {
+  const DiaryData({
+    required this.userName,
+    this.avatarUrl,
+    required this.diaryText,
+    required this.isBookmarked,
+  });
+  final String userName;
+  final String? avatarUrl;
+  final String diaryText;
+  final bool isBookmarked;
 }

--- a/lib/diaryList.dart
+++ b/lib/diaryList.dart
@@ -40,19 +40,40 @@ const dummyDiaryDataListBase = [
   DiaryData(
     userName: "みどり",
     avatarUrl: null,
+    diaryKind: DiaryKind.fiveSenses,
     diaryText: "視覚：おいしそうなごはん\n聴覚：楽しい音楽\n触覚：さむい\n味覚：唐揚げおいしい\n嗅覚：？？？？？？？",
     isBookmarked: false,
   ),
   DiaryData(
     userName: "青子",
     avatarUrl: dummyAvatarUrl,
+    diaryKind: DiaryKind.myPastSelf,
     diaryText: "過去の自分へ\n\n友達ができないと悩んでいた私へ\n名前が覚えられないほど仲間ができたよ",
     isBookmarked: false,
   ),
   DiaryData(
     userName: "赤太郎",
-    avatarUrl: null,
+    avatarUrl:
+        "https://2.bp.blogspot.com/-N-arJtghbKE/U2LufzJMYvI/AAAAAAAAfrQ/vNikhC7vEwM/s800/taiiku_cap_red.png",
+    diaryKind: DiaryKind.free,
     diaryText: "困っていること\n\nストレス、疲れに気づかない\n完ぺき主義",
+    isBookmarked: true,
+  ),
+  DiaryData(
+    userName: "涼風",
+    avatarUrl:
+        "https://4.bp.blogspot.com/-EgN4TJMFaG8/WK7fDLuYLkI/AAAAAAABCAg/S8QMbWC_6F0Vt9dCg4Scq4jOkeL0bDghgCLcB/s800/mahoutsukai_wind.png",
+    diaryKind: DiaryKind.becomeYourFutureSelf,
+    diaryText: "未来の自分へ\n\n支援を受けて１年後には自立した生活を送り、就職して働けるようになっていたい",
+    isBookmarked: false,
+  ),
+  DiaryData(
+    userName: "西陽",
+    avatarUrl:
+        "https://4.bp.blogspot.com/-pDC6umJH8H4/UbVvXL3PPEI/AAAAAAAAUwE/7IzHI_SmA40/s800/vacation_sunset.png",
+    diaryKind: DiaryKind.serviceUsed,
+    diaryText:
+        "生活保護相談サービスを利用\n\nカウンセラーの方は今後の指針について親身になって相談に乗ってくれた\n来週一緒に役所に同行してくれることになった",
     isBookmarked: true,
   ),
 ];
@@ -72,11 +93,21 @@ class DiaryData {
   const DiaryData({
     required this.userName,
     this.avatarUrl,
+    required this.diaryKind,
     required this.diaryText,
     required this.isBookmarked,
   });
   final String userName;
   final String? avatarUrl;
+  final DiaryKind diaryKind;
   final String diaryText;
   final bool isBookmarked;
+}
+
+enum DiaryKind {
+  fiveSenses,
+  myPastSelf,
+  becomeYourFutureSelf,
+  serviceUsed,
+  free,
 }

--- a/lib/diaryList.dart
+++ b/lib/diaryList.dart
@@ -14,6 +14,7 @@ class DiaryList extends StatelessWidget {
         return DiaryListItem(
           userName: dummyDiaryDataList[index].userName,
           avatarUrl: dummyDiaryDataList[index].avatarUrl,
+          diaryKind: dummyDiaryDataList[index].diaryKind,
           diaryText: dummyDiaryDataList[index].diaryText,
           isBookmarked: dummyDiaryDataList[index].isBookmarked,
           onTapBookmark: () {},

--- a/lib/diaryListItem.dart
+++ b/lib/diaryListItem.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+class DiaryListItem extends StatelessWidget {
+  const DiaryListItem({
+    Key? key,
+    required this.userName,
+    this.avatarUrl,
+    required this.diaryText,
+    required this.isBookmarked,
+    required this.onTapBookmark,
+  }) : super(key: key);
+
+  final String userName;
+  final String? avatarUrl;
+  final String diaryText;
+  final bool isBookmarked;
+  final VoidCallback onTapBookmark;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      child: Row(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
+            child: Column(
+              children: [
+                avatarUrl != null
+                    ? CircleAvatar(
+                        backgroundImage: NetworkImage(avatarUrl!),
+                      )
+                    : CircleAvatar(
+                        backgroundColor: Colors.grey,
+                        child: Text(
+                          userName.isNotEmpty ? userName[0] : "NaN",
+                          style: const TextStyle(
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                const SizedBox(height: 8),
+                Text(
+                  userName,
+                  style: const TextStyle(
+                    color: Colors.black,
+                    fontSize: 16,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(0, 10, 20, 10),
+              child: SizedBox(
+                width: double.infinity,
+                child: Text(
+                  diaryText,
+                  style: const TextStyle(
+                    color: Colors.black,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: IconButton(
+              icon: Icon(
+                isBookmarked ? Icons.bookmark : Icons.bookmark_border,
+              ),
+              onPressed: onTapBookmark,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/diaryListItem.dart
+++ b/lib/diaryListItem.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:omurice/diaryList.dart';
 
 class DiaryListItem extends StatelessWidget {
   const DiaryListItem({
     Key? key,
     required this.userName,
     this.avatarUrl,
+    required this.diaryKind,
     required this.diaryText,
     required this.isBookmarked,
     required this.onTapBookmark,
@@ -12,6 +14,7 @@ class DiaryListItem extends StatelessWidget {
 
   final String userName;
   final String? avatarUrl;
+  final DiaryKind diaryKind;
   final String diaryText;
   final bool isBookmarked;
   final VoidCallback onTapBookmark;
@@ -66,15 +69,60 @@ class DiaryListItem extends StatelessWidget {
           ),
           Padding(
             padding: const EdgeInsets.all(10),
-            child: IconButton(
-              icon: Icon(
-                isBookmarked ? Icons.bookmark : Icons.bookmark_border,
-              ),
-              onPressed: onTapBookmark,
+            child: Column(
+              children: [
+                getChip(diaryKind),
+                IconButton(
+                  icon: Icon(
+                    isBookmarked ? Icons.bookmark : Icons.bookmark_border,
+                  ),
+                  onPressed: onTapBookmark,
+                ),
+              ],
             ),
           ),
         ],
       ),
     );
+  }
+}
+
+Widget getChip(DiaryKind kind) {
+  switch (kind) {
+    case DiaryKind.fiveSenses:
+      {
+        return Chip(
+          label: const Text("五感"),
+          backgroundColor: Colors.red[100],
+        );
+      }
+    case DiaryKind.myPastSelf:
+      {
+        return Chip(
+          label: const Text("過去"),
+          backgroundColor: Colors.blue[100],
+        );
+      }
+    case DiaryKind.becomeYourFutureSelf:
+      {
+        return Chip(
+          label: const Text("未来"),
+          backgroundColor: Colors.amber[100],
+        );
+      }
+    case DiaryKind.serviceUsed:
+      {
+        return Chip(
+          label: const Text("経験"),
+          backgroundColor: Colors.purple[100],
+        );
+      }
+    case DiaryKind.free:
+      {
+        return Chip(
+          label: const Text("自由"),
+          backgroundColor: Colors.green[100],
+        );
+      }
   }
 }

--- a/lib/diaryView.dart
+++ b/lib/diaryView.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:omurice/component/serchWidget.dart';
+import 'package:omurice/component/searchWidget.dart';
 import 'package:omurice/diaryList.dart';
 
 class DiaryView extends StatelessWidget {

--- a/lib/diaryView.dart
+++ b/lib/diaryView.dart
@@ -16,6 +16,7 @@ class DiaryView extends StatelessWidget {
           onTap: focusNode.requestFocus,
           child: Scaffold(
             appBar: AppBar(
+              elevation: 4,
               backgroundColor: Colors.white,
               automaticallyImplyLeading: false,
               flexibleSpace: const Center(
@@ -27,10 +28,14 @@ class DiaryView extends StatelessWidget {
                 ),
               ),
               bottom: TabBar(
+                labelColor: Colors.black,
+                labelStyle: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
                 onTap: (value) => {
                   focusNode.requestFocus(),
                 },
-                labelColor: Colors.black,
                 tabs: const [
                   Tab(text: "自分"),
                   Tab(text: "フォロー"),

--- a/lib/diaryView.dart
+++ b/lib/diaryView.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:omurice/component/serchWidget.dart';
+import 'package:omurice/diaryList.dart';
+
+class DiaryView extends StatelessWidget {
+  const DiaryView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final focusNode = FocusNode();
+    return DefaultTabController(
+      length: 3,
+      child: Focus(
+        focusNode: focusNode,
+        child: GestureDetector(
+          onTap: focusNode.requestFocus,
+          child: Scaffold(
+            appBar: AppBar(
+              backgroundColor: Colors.white,
+              automaticallyImplyLeading: false,
+              flexibleSpace: const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(24),
+                  child: SearchWidget(
+                    hint: "キーワードで検索",
+                  ),
+                ),
+              ),
+              bottom: TabBar(
+                onTap: (value) => {
+                  focusNode.requestFocus(),
+                },
+                labelColor: Colors.black,
+                tabs: const [
+                  Tab(text: "自分"),
+                  Tab(text: "フォロー"),
+                  Tab(text: "タイムライン"),
+                ],
+              ),
+            ),
+            body: const TabBarView(
+              children: [
+                DiaryList(mode: Mode.myself),
+                DiaryList(mode: Mode.follow),
+                DiaryList(mode: Mode.timeline),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/navHost.dart
+++ b/lib/navHost.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:omurice/diaryFormatChoiceScreen.dart';
+import 'package:omurice/diaryView.dart';
 import 'component/bottomIconBar.dart';
 import 'sampleScreen.dart';
 
@@ -20,7 +21,7 @@ class NavHost extends StatefulWidget {
 class _NavHostState extends State<NavHost> {
   List<Widget> display = [
     const DiaryFormatChoiceScreen(),
-    const Sample(label: "「日記を見る」ページ"),
+    const DiaryView(),
     const Sample(label: "サービス・支援ページ"),
     const Sample(label: "ユーザーページ")
   ];
@@ -86,6 +87,6 @@ class _NavHostState extends State<NavHost> {
   }
 
   bool isAppBarShowed(int selectedIndex) {
-    return selectedIndex != 0;
+    return selectedIndex > 1;
   }
 }


### PR DESCRIPTION
## 対応内容

* 日記閲覧画面の作成
* 日記リストウィジェット、日記リスト項目ウィジェットを追加
* SearchWidgetを配置
  - 画面に合わせて少しカスタマイズ（ヒント文字列を設定可能にした）
* ダミーデータを定義

## 画面

https://user-images.githubusercontent.com/3205581/216721733-aff4cdb0-40ad-48d5-acf1-372747dc6fc3.mov
