### PR TITLE
日記を投稿する機能を追加

### DIFF
--- a/lib/pages/diary_format_choice_screen.dart
+++ b/lib/pages/diary_format_choice_screen.dart
@@ -83,7 +83,7 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                 Text("特別な日記"),
               ],
             ),
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
             TextButton(
               child: const Text(
                 "五感日記",
@@ -131,7 +131,7 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                 );
               },
             ),
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
             TextButton(
               child: const Text(
                 "未来の自分になりきって",
@@ -155,7 +155,7 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                 );
               },
             ),
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
             TextButton(
               child: const Text(
                 "使ったサービス",

--- a/lib/pages/diary_format_choice_screen.dart
+++ b/lib/pages/diary_format_choice_screen.dart
@@ -85,7 +85,7 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
             ),
             SizedBox(height: 20),
             TextButton(
-              child: Text(
+              child: const Text(
                 "五感日記",
                 style: TextStyle(
                   fontSize: 18,
@@ -107,9 +107,9 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                 );
               },
             ),
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
             TextButton(
-              child: Text(
+              child: const Text(
                 "過去の自分へ",
                 style: TextStyle(
                   fontSize: 18,
@@ -133,7 +133,7 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
             ),
             SizedBox(height: 20),
             TextButton(
-              child: Text(
+              child: const Text(
                 "未来の自分になりきって",
                 style: TextStyle(
                   fontSize: 18,
@@ -157,7 +157,7 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
             ),
             SizedBox(height: 20),
             TextButton(
-              child: Text(
+              child: const Text(
                 "使ったサービス",
                 style: TextStyle(
                   fontSize: 18,

--- a/lib/pages/diary_format_choice_screen.dart
+++ b/lib/pages/diary_format_choice_screen.dart
@@ -2,6 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:omurice/pages/diary_screen.dart';
 
+enum DiaryKind {
+  /* 五感日記 */
+  fiveSenses(id: 1),
+  /* 未来の自分になりきって */
+  futureSelf(id: 2),
+  /* 過去の自分へ */
+  pastSelf(id: 3),
+  /* 使ったサービス */
+  usedServices(id: 4),
+  /* 自由形式 */
+  free(id: 5);
+
+  const DiaryKind({required this.id});
+
+  final int id;
+}
+
 class DiaryFormatChoiceScreen extends StatefulWidget {
   const DiaryFormatChoiceScreen({Key? key}) : super(key: key);
 
@@ -49,7 +66,10 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (_) => const DiaryCreateScreen(format: ""),
+                      builder: (_) => DiaryCreateScreen(
+                        kindId: DiaryKind.free.id,
+                        format: "",
+                      ),
                       fullscreenDialog: true,
                     ),
                   );
@@ -78,8 +98,10 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) =>
-                        const DiaryCreateScreen(format: fiveSensesDiaryFormat),
+                    builder: (_) => DiaryCreateScreen(
+                      kindId: DiaryKind.fiveSenses.id,
+                      format: fiveSensesDiaryFormat,
+                    ),
                     fullscreenDialog: true,
                   ),
                 );
@@ -100,8 +122,10 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) =>
-                        const DiaryCreateScreen(format: myPastSelfFormat),
+                    builder: (_) => DiaryCreateScreen(
+                      kindId: DiaryKind.pastSelf.id,
+                      format: myPastSelfFormat,
+                    ),
                     fullscreenDialog: true,
                   ),
                 );
@@ -122,8 +146,10 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) => const DiaryCreateScreen(
-                        format: becomeYourFutureSelfFormat),
+                    builder: (_) => DiaryCreateScreen(
+                      kindId: DiaryKind.futureSelf.id,
+                      format: becomeYourFutureSelfFormat,
+                    ),
                     fullscreenDialog: true,
                   ),
                 );
@@ -144,8 +170,10 @@ class _DiaryFormatChoiceScreenState extends State<DiaryFormatChoiceScreen> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) =>
-                        const DiaryCreateScreen(format: servicesUsedFormat),
+                    builder: (_) => DiaryCreateScreen(
+                      kindId: DiaryKind.usedServices.id,
+                      format: servicesUsedFormat,
+                    ),
                     fullscreenDialog: true,
                   ),
                 );

--- a/lib/pages/diary_screen.dart
+++ b/lib/pages/diary_screen.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class DiaryCreateScreen extends StatefulWidget {
   const DiaryCreateScreen({
     Key? key,
+    required this.kindId,
     required this.format,
   }) : super(key: key);
 
+  final int kindId;
   final String format;
 
   @override
@@ -16,11 +19,23 @@ class DiaryCreateScreen extends StatefulWidget {
 class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
   TextEditingController? _controller;
   bool isSaveNeeded = false;
+  final supabase = Supabase.instance.client;
 
   @override
   void initState() {
     _controller = TextEditingController(text: widget.format);
     super.initState();
+  }
+
+  Future<void> insertDiary(String diaryText) async {
+    final currentUserID = supabase.auth.currentUser!.id;
+    await supabase.from('diary').insert({
+      'date': '2023-03-23', // todo 作成日の日付
+      // 'user_id': currentUserID,
+      'user_id': 5, // todo userId
+      'kind_id': widget.kindId,
+      'text': diaryText
+    });
   }
 
   @override
@@ -108,7 +123,11 @@ class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
                             child: ElevatedButton(
                               style: ElevatedButton.styleFrom(
                                   backgroundColor: Colors.black12),
-                              onPressed: () {},
+                              onPressed: () {
+                                if (_controller?.text != null) {
+                                  insertDiary(_controller!.text);
+                                }
+                              },
                               child: const Text(
                                 "投稿",
                                 style: TextStyle(

--- a/lib/pages/diary_screen.dart
+++ b/lib/pages/diary_screen.dart
@@ -28,14 +28,19 @@ class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
     super.initState();
   }
 
-  Future<void> insertDiary(String diaryText) async {
+  Future<bool> insertDiary(String diaryText) async {
     var now = DateTime.now();
-    await supabase.from('diary').insert({
-      'date': "${now.year}-${now.month}-${now.day}",
-      'user_id': 5, // todo userId
-      'kind_id': widget.kindId,
-      'text': diaryText
-    });
+    try {
+      await supabase.from('diary').insert({
+        'date': "${now.year}-${now.month}-${now.day}",
+        'user_id': 5, // todo userId
+        'kind_id': widget.kindId,
+        'text': diaryText
+      });
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 
   @override
@@ -123,30 +128,32 @@ class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
                                   backgroundColor: Colors.black12),
                               onPressed: () {
                                 if (_controller?.text != null) {
-                                  try {
-                                    insertDiary(_controller!.text);
-                                    const snackBar = SnackBar(
-                                      content: Text('日記を投稿しました'),
-                                    );
-                                    ScaffoldMessenger.of(context)
-                                        .showSnackBar(snackBar);
-                                    // 日記一覧画面に移動
-                                    Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (_) => const NavHost(
-                                          title: "",
-                                          selectedIndex: 1,
+                                  insertDiary(_controller!.text)
+                                      .then((isSuccess) {
+                                    if (isSuccess) {
+                                      const snackBar = SnackBar(
+                                        content: Text('日記を投稿しました'),
+                                      );
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(snackBar);
+                                      // 日記一覧画面に移動
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (_) => const NavHost(
+                                            title: "",
+                                            selectedIndex: 1,
+                                          ),
                                         ),
-                                      ),
-                                    );
-                                  } catch (e) {
-                                    const snackBar = SnackBar(
-                                      content: Text('日記の投稿に失敗しました'),
-                                    );
-                                    ScaffoldMessenger.of(context)
-                                        .showSnackBar(snackBar);
-                                  }
+                                      );
+                                    } else {
+                                      const snackBar = SnackBar(
+                                        content: Text('日記の投稿に失敗しました'),
+                                      );
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(snackBar);
+                                    }
+                                  });
                                 }
                               },
                               child: const Text(

--- a/lib/pages/diary_screen.dart
+++ b/lib/pages/diary_screen.dart
@@ -29,9 +29,9 @@ class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
 
   Future<void> insertDiary(String diaryText) async {
     final currentUserID = supabase.auth.currentUser!.id;
+    var now = DateTime.now();
     await supabase.from('diary').insert({
-      'date': '2023-03-23', // todo 作成日の日付
-      // 'user_id': currentUserID,
+      'date': "${now.year}-${now.month}-${now.day}",
       'user_id': 5, // todo userId
       'kind_id': widget.kindId,
       'text': diaryText

--- a/lib/pages/diary_screen.dart
+++ b/lib/pages/diary_screen.dart
@@ -28,7 +28,6 @@ class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
   }
 
   Future<void> insertDiary(String diaryText) async {
-    final currentUserID = supabase.auth.currentUser!.id;
     var now = DateTime.now();
     await supabase.from('diary').insert({
       'date': "${now.year}-${now.month}-${now.day}",
@@ -68,23 +67,21 @@ class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
                   height: double.infinity,
                   child: Padding(
                     padding: const EdgeInsets.all(16.0),
-                    child: Expanded(
-                      child: TextField(
-                        controller: _controller,
-                        style: const TextStyle(
-                          fontSize: 24,
-                        ),
-                        decoration: const InputDecoration(
-                          border: InputBorder.none,
-                        ),
-                        keyboardType: TextInputType.multiline,
-                        maxLines: null,
-                        onChanged: (value) {
-                          setState(() {
-                            isSaveNeeded = value.isNotEmpty;
-                          });
-                        },
+                    child: TextField(
+                      controller: _controller,
+                      style: const TextStyle(
+                        fontSize: 24,
                       ),
+                      decoration: const InputDecoration(
+                        border: InputBorder.none,
+                      ),
+                      keyboardType: TextInputType.multiline,
+                      maxLines: null,
+                      onChanged: (value) {
+                        setState(() {
+                          isSaveNeeded = value.isNotEmpty;
+                        });
+                      },
                     ),
                   ),
                   // ),

--- a/lib/pages/diary_screen.dart
+++ b/lib/pages/diary_screen.dart
@@ -125,7 +125,21 @@ class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
                                   backgroundColor: Colors.black12),
                               onPressed: () {
                                 if (_controller?.text != null) {
-                                  insertDiary(_controller!.text);
+                                  try {
+                                    insertDiary(_controller!.text);
+                                    const snackBar = SnackBar(
+                                      content: Text('日記を投稿しました'),
+                                    );
+                                    ScaffoldMessenger.of(context)
+                                        .showSnackBar(snackBar);
+                                    // todo 日記一覧画面に移動
+                                  } catch (e) {
+                                    const snackBar = SnackBar(
+                                      content: Text('日記の投稿に失敗しました'),
+                                    );
+                                    ScaffoldMessenger.of(context)
+                                        .showSnackBar(snackBar);
+                                  }
                                 }
                               },
                               child: const Text(

--- a/lib/pages/diary_screen.dart
+++ b/lib/pages/diary_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:omurice/pages/nav_host.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class DiaryCreateScreen extends StatefulWidget {
@@ -129,7 +130,16 @@ class _DiaryCreateScreenState extends State<DiaryCreateScreen> {
                                     );
                                     ScaffoldMessenger.of(context)
                                         .showSnackBar(snackBar);
-                                    // todo 日記一覧画面に移動
+                                    // 日記一覧画面に移動
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (_) => const NavHost(
+                                          title: "",
+                                          selectedIndex: 1,
+                                        ),
+                                      ),
+                                    );
                                   } catch (e) {
                                     const snackBar = SnackBar(
                                       content: Text('日記の投稿に失敗しました'),


### PR DESCRIPTION
## Why

- 日記を投稿したい

## What

- 日記作成画面にて投稿ボタンが押下された場合、Supabaseのdiaryテーブルに対してinsert処理を実行
  - 投稿成功時には、トースト通知を行い、日記一覧画面に遷移する
  - 投稿失敗時には、トースト通知を行い、日記作成画面に留まる

## 動画

https://user-images.githubusercontent.com/3205581/227532534-6d6d91c6-3eb4-4fde-99ae-fb3eaa371f2f.mov
- 日記投稿を行い、DBに登録されることを確認
- ネットワークを切断した状態で日記投稿を行い、エラー通知がされることを確認
- (容量制限のため解像度を落としています)